### PR TITLE
Add JSONMarshaler as alternative to GobMarshaler

### DIFF
--- a/pkg/jetstream/marshaler_test.go
+++ b/pkg/jetstream/marshaler_test.go
@@ -2,9 +2,10 @@ package jetstream_test
 
 import (
 	"fmt"
-	"github.com/nats-io/nats.go"
 	"sync"
 	"testing"
+
+	"github.com/nats-io/nats.go"
 
 	"github.com/stretchr/testify/assert"
 
@@ -41,6 +42,57 @@ func TestGobMarshaler(t *testing.T) {
 
 func TestGobMarshaler_multiple_messages_async(t *testing.T) {
 	marshaler := jetstream.GobMarshaler{}
+
+	messagesCount := 1000
+	wg := sync.WaitGroup{}
+	wg.Add(messagesCount)
+
+	for i := 0; i < messagesCount; i++ {
+		go func(msgNum int) {
+			defer wg.Done()
+
+			msg := message.NewMessage(fmt.Sprintf("%d", msgNum), nil)
+
+			b, err := marshaler.Marshal("topic", msg)
+			require.NoError(t, err)
+
+			unmarshaledMsg, err := marshaler.Unmarshal(&nats.Msg{Data: b})
+
+			require.NoError(t, err)
+
+			assert.True(t, msg.Equals(unmarshaledMsg))
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestJSONMarshaler(t *testing.T) {
+	msg := message.NewMessage("1", []byte("zag"))
+	msg.Metadata.Set("foo", "bar")
+
+	marshaler := jetstream.JSONMarshaler{}
+
+	b, err := marshaler.Marshal("topic", msg)
+	require.NoError(t, err)
+
+	unmarshaledMsg, err := marshaler.Unmarshal(&nats.Msg{Data: b})
+	require.NoError(t, err)
+
+	assert.True(t, msg.Equals(unmarshaledMsg))
+
+	unmarshaledMsg.Ack()
+
+	select {
+	case <-unmarshaledMsg.Acked():
+		// ok
+	default:
+		t.Fatal("ack is not working")
+	}
+}
+
+func TestJSONMarshaler_multiple_messages_async(t *testing.T) {
+	marshaler := jetstream.JSONMarshaler{}
 
 	messagesCount := 1000
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
To support more polyglot environments, I added a JSONMarshaler as alternative to the GobMarshaler.

I've also copied your tests and changed them to fit the JSONMarshaler.